### PR TITLE
Add RAILS_ENV to docker-compose environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+RAILS_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,5 @@ services:
     build: .
     ports:
       - 3000:3000
+    environment:
+      RAILS_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
     ports:
       - 3000:3000
     environment:
-      RAILS_ENV: production
+      RAILS_ENV: ${RAILS_ENV}


### PR DESCRIPTION
We can also add a `.env` file with environment variables like these and access them like:
```yaml
RAILS_ENV: ${RAILS_ENV}
```
in compose. But it would be less convenient to copy the content of the folder because .env could be overwritten